### PR TITLE
fix: Correct script entry point for `ixbrlparse`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -170,5 +170,5 @@ tests = ["tests", "*/ixbrlparse/tests"]
 [tool.coverage.report]
 exclude_lines = ["no cov", "if __name__ == .__main__.:", "if TYPE_CHECKING:"]
 
-[tool.hatch.build.targets.sdist]
-include = ["/ixbrlparse"]
+[tool.hatch.build]
+packages = ["src/ixbrlparse"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,7 +44,7 @@ Issues = "https://github.com/kanedata/ixbrl-parse/issues"
 Source = "https://github.com/kanedata/ixbrl-parse"
 
 [project.scripts]
-ixbrlparse = "ixbrlparse.cli:ixbrlparse"
+ixbrlparse = "ixbrlparse.cli:ixbrlparse_cli"
 
 [tool.hatch.version]
 path = "src/ixbrlparse/__about__.py"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -3,12 +3,18 @@ import json
 import subprocess
 import sys
 
+import pytest
 from click.testing import CliRunner
 
 import ixbrlparse.__main__ as ixmain
 from ixbrlparse.cli import ixbrlparse_cli
 
 _ = ixmain
+
+cli_options = [
+    [sys.executable, "-m", "ixbrlparse"],
+    ["ixbrlparse"],
+]
 
 
 def test_cli():
@@ -22,13 +28,12 @@ def test_cli():
     assert ",CurrentAssets,2909.0," in buffer.getvalue()
 
 
-def test_cli_raw(tmp_path):
+@pytest.mark.parametrize("cli_command", cli_options)
+def test_cli_raw(tmp_path, cli_command):
     f = tmp_path / "output.csv"
     result = subprocess.run(  # noqa: S603
         [
-            sys.executable,
-            "-m",
-            "ixbrlparse",
+            *cli_command,
             "--outfile",
             str(f),
             "tests/test_accounts/account_1.html",
@@ -61,13 +66,12 @@ def test_cli_json():
     assert data["numeric"][2]["value"] == 2909.0
 
 
-def test_cli_json_raw(tmp_path):
+@pytest.mark.parametrize("cli_command", cli_options)
+def test_cli_json_raw(tmp_path, cli_command):
     f = tmp_path / "output.json"
     result = subprocess.run(  # noqa: S603
         [
-            sys.executable,
-            "-m",
-            "ixbrlparse",
+            *cli_command,
             "--outfile",
             str(f),
             "--format",
@@ -103,13 +107,12 @@ def test_cli_unknown_format():
     assert not data
 
 
-def test_cli_unknown_format_raw(tmp_path):
+@pytest.mark.parametrize("cli_command", cli_options)
+def test_cli_unknown_format_raw(tmp_path, cli_command):
     f = tmp_path / "output.txt"
     result = subprocess.run(  # noqa: S603
         [
-            sys.executable,
-            "-m",
-            "ixbrlparse",
+            *cli_command,
             "--outfile",
             str(f),
             "--format",
@@ -149,13 +152,12 @@ def test_cli_jsonl():
         raise AssertionError(msg)
 
 
-def test_cli_jsonl_raw(tmp_path):
+@pytest.mark.parametrize("cli_command", cli_options)
+def test_cli_jsonl_raw(tmp_path, cli_command):
     f = tmp_path / "output.jsonl"
     result = subprocess.run(  # noqa: S603
         [
-            sys.executable,
-            "-m",
-            "ixbrlparse",
+            *cli_command,
             "--outfile",
             str(f),
             "--format",


### PR DESCRIPTION
This pull request addresses an issue where the `ixbrlparse` command would fail after package installation due to an incorrect entry point definition in `pyproject.toml`.

The entry point was incorrectly pointing to `ixbrlparse.cli:ixbrlparse`, which is a non-existent function.

This has been corrected to point to the proper `ixbrlparse.cli:ixbrlparse_cli` function, ensuring that the command-line interface runs as intended.